### PR TITLE
Add rebinned EELS dataset

### DIFF
--- a/3_MachineLearning_Plasmonic_EELS_BlindSourceSeparation.ipynb
+++ b/3_MachineLearning_Plasmonic_EELS_BlindSourceSeparation.ipynb
@@ -128,7 +128,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s = hs.load('data/Bipyramid_EELS_zlp_aligned_spikes_removed.hspy')"
+    "s = hs.load('data/Bipyramid_EELS_zlp_aligned_spikes_removed_rebinned.hspy')"
    ]
   },
   {


### PR DESCRIPTION
I have added a rebinned dataset <25 Mb in size to the data folder.

I have also amended the Machine learning .ipynb file to point to the new file name (rebinned file).

I have checked that the rebinned version produces similar results on my installation.